### PR TITLE
新增redis健康检查功能

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,17 +4,13 @@
 
 	<groupId>org.ansj</groupId>
 	<artifactId>elasticsearch-analysis-ansj</artifactId>
-	<version>2.3.3</version>
+	<version>2.4.0.2</version>
 	<description>elasticsearch analysis by ansj</description>
 	<name>elasticsearch-analysis-ansj</name>
 	<url>http://maven.nlpcn.org</url>
 
 
 	<repositories>
-			<repository>
-			<id>nexus</id>
-			<url>http://10.204.12.34:8081/repository/maven-public/</url>
-		</repository>
 		<repository>
 			<id>mvn-repo</id>
 			<url>http://maven.nlpcn.org/</url>
@@ -35,7 +31,7 @@
 		<elasticsearch.plugin.name>elasticsearch-analysis-ansj</elasticsearch.plugin.name>
 		<elasticsearch.plugin.site>true</elasticsearch.plugin.site>
 		<elasticsearch.plugin.jvm>true</elasticsearch.plugin.jvm>
-		<elasticsearch.version>2.3.3</elasticsearch.version>
+		<elasticsearch.version>2.4.0</elasticsearch.version>
 		<elasticsearch.plugin.classname>org.ansj.elasticsearch.plugin.AnalysisAnsjPlugin</elasticsearch.plugin.classname>
 	</properties>
 
@@ -79,55 +75,54 @@
 
 	</dependencies>
 	<build>
+		<plugins>
+			<plugin>
+				<groupId>net.orfjackal.retrolambda</groupId>
+				<artifactId>retrolambda-maven-plugin</artifactId>
+				<version>2.3.0</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>process-main</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<target>1.6</target>
+					<defaultMethods>false</defaultMethods>
+					<fork>false</fork>
+				</configuration>
+			</plugin>
 		
-			<plugins>
-				<plugin>
-					<groupId>net.orfjackal.retrolambda</groupId>
-					<artifactId>retrolambda-maven-plugin</artifactId>
-					<version>2.3.0</version>
-					<executions>
-						<execution>
-							<goals>
-								<goal>process-main</goal>
-							</goals>
-						</execution>
-					</executions>
-					<configuration>
-						<target>1.6</target>
-						<defaultMethods>false</defaultMethods>
-						<fork>false</fork>
-					</configuration>
-				</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
+				<configuration>
+					<source>1.7</source>
+					<target>1.7</target>
+				</configuration>
+			</plugin>
 
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-compiler-plugin</artifactId>
-					<version>3.3</version>
-					<configuration>
-						<source>1.7</source>
-						<target>1.7</target>
-					</configuration>
-				</plugin>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<configuration>
+					<outputDirectory>${project.build.directory}/releases/</outputDirectory>
+					<descriptors>
+						<descriptor>${basedir}/src/main/assembly/plugin.xml</descriptor>
+					</descriptors>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 
-				<plugin>
-					<artifactId>maven-assembly-plugin</artifactId>
-					<configuration>
-						<outputDirectory>${project.build.directory}/releases/</outputDirectory>
-						<descriptors>
-							<descriptor>${basedir}/src/main/assembly/plugin.xml</descriptor>
-						</descriptors>
-					</configuration>
-					<executions>
-						<execution>
-							<phase>package</phase>
-							<goals>
-								<goal>single</goal>
-							</goals>
-						</execution>
-					</executions>
-				</plugin>
-			</plugins>
-		
 		<extensions>
 			<extension>
 				<groupId>org.apache.maven.wagon</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,13 +4,17 @@
 
 	<groupId>org.ansj</groupId>
 	<artifactId>elasticsearch-analysis-ansj</artifactId>
-	<version>2.4.0.2</version>
+	<version>2.3.3</version>
 	<description>elasticsearch analysis by ansj</description>
 	<name>elasticsearch-analysis-ansj</name>
 	<url>http://maven.nlpcn.org</url>
 
 
 	<repositories>
+			<repository>
+			<id>nexus</id>
+			<url>http://10.204.12.34:8081/repository/maven-public/</url>
+		</repository>
 		<repository>
 			<id>mvn-repo</id>
 			<url>http://maven.nlpcn.org/</url>
@@ -31,7 +35,7 @@
 		<elasticsearch.plugin.name>elasticsearch-analysis-ansj</elasticsearch.plugin.name>
 		<elasticsearch.plugin.site>true</elasticsearch.plugin.site>
 		<elasticsearch.plugin.jvm>true</elasticsearch.plugin.jvm>
-		<elasticsearch.version>2.4.0</elasticsearch.version>
+		<elasticsearch.version>2.3.3</elasticsearch.version>
 		<elasticsearch.plugin.classname>org.ansj.elasticsearch.plugin.AnalysisAnsjPlugin</elasticsearch.plugin.classname>
 	</properties>
 
@@ -75,54 +79,55 @@
 
 	</dependencies>
 	<build>
-		<plugins>
-			<plugin>
-				<groupId>net.orfjackal.retrolambda</groupId>
-				<artifactId>retrolambda-maven-plugin</artifactId>
-				<version>2.3.0</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>process-main</goal>
-						</goals>
-					</execution>
-				</executions>
-				<configuration>
-					<target>1.6</target>
-					<defaultMethods>false</defaultMethods>
-					<fork>false</fork>
-				</configuration>
-			</plugin>
 		
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.3</version>
-				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
-				</configuration>
-			</plugin>
+			<plugins>
+				<plugin>
+					<groupId>net.orfjackal.retrolambda</groupId>
+					<artifactId>retrolambda-maven-plugin</artifactId>
+					<version>2.3.0</version>
+					<executions>
+						<execution>
+							<goals>
+								<goal>process-main</goal>
+							</goals>
+						</execution>
+					</executions>
+					<configuration>
+						<target>1.6</target>
+						<defaultMethods>false</defaultMethods>
+						<fork>false</fork>
+					</configuration>
+				</plugin>
 
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<outputDirectory>${project.build.directory}/releases/</outputDirectory>
-					<descriptors>
-						<descriptor>${basedir}/src/main/assembly/plugin.xml</descriptor>
-					</descriptors>
-				</configuration>
-				<executions>
-					<execution>
-						<phase>package</phase>
-						<goals>
-							<goal>single</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.3</version>
+					<configuration>
+						<source>1.7</source>
+						<target>1.7</target>
+					</configuration>
+				</plugin>
 
+				<plugin>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<configuration>
+						<outputDirectory>${project.build.directory}/releases/</outputDirectory>
+						<descriptors>
+							<descriptor>${basedir}/src/main/assembly/plugin.xml</descriptor>
+						</descriptors>
+					</configuration>
+					<executions>
+						<execution>
+							<phase>package</phase>
+							<goals>
+								<goal>single</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
+			</plugins>
+		
 		<extensions>
 			<extension>
 				<groupId>org.apache.maven.wagon</groupId>

--- a/src/main/java/org/ansj/elasticsearch/entities/RedisStatusEntity.java
+++ b/src/main/java/org/ansj/elasticsearch/entities/RedisStatusEntity.java
@@ -1,0 +1,34 @@
+package org.ansj.elasticsearch.entities;
+
+import org.elasticsearch.common.settings.Settings;
+
+public class RedisStatusEntity {
+	private static Settings essettings;
+	private static boolean redischeckdeamonalived = false;
+	private static long redisthreadid;
+
+	public static Settings getEssettings() {
+		return essettings;
+	}
+
+	public static void setEssettings(Settings essettings) {
+		RedisStatusEntity.essettings = essettings;
+	}
+
+	public static boolean isRedischeckdeamonalived() {
+		return redischeckdeamonalived;
+	}
+
+	public static void setRedischeckdeamonalived(boolean redischeckdeamonalived) {
+		RedisStatusEntity.redischeckdeamonalived = redischeckdeamonalived;
+	}
+
+	public static long getRedisthreadid() {
+		return redisthreadid;
+	}
+
+	public static void setRedisthreadid(long redisthreadid) {
+		RedisStatusEntity.redisthreadid = redisthreadid;
+	}
+
+}


### PR DESCRIPTION
主要针对redis服务器链接失败后，热词不能推送问题。
修改src/main/java/org/ansj/elasticsearch/index/config/AnsjElasticConfigurator.java，新增健康检查线程。
redis线程失败后，重启该线程。